### PR TITLE
Updated the docker files so that they work with 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN rm -rf /tmp/*
 RUN apt-get update -y --quiet ; apt-get install -y python3-pip python3-numpy
 RUN pip3 install --upgrade pip==21.1.1 ; pip3 install --upgrade pandas==0.24.2
 RUN nimble -y refresh ; nimble -y install nimpy@0.1.1
-ADD src/faster_than_csv.nim /tmp/
+ADD faster_than_csv/faster_than_csv.nim /tmp/
 RUN nim c -d:danger -d:lto -d:strip --app:lib --gc:arc --passC:"-march=native" --passC:"-ffast-math" --out:/tmp/faster_than_csv.so /tmp/faster_than_csv.nim
 ADD benchmark.py /tmp/
 ADD sample.csv /tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM nimlang/nim
 RUN rm -rf /tmp/*
 RUN apt-get update -y --quiet ; apt-get install -y python3-pip python3-numpy
 RUN pip3 install --upgrade pip==21.1.1 ; pip3 install --upgrade pandas==0.24.2
-RUN nimble -y refresh ; nimble -y install nimpy@0.1.0
+RUN nimble -y refresh ; nimble -y install nimpy@0.1.1
 ADD src/faster_than_csv.nim /tmp/
 RUN nim c -d:danger -d:lto -d:strip --app:lib --gc:arc --passC:"-march=native" --passC:"-ffast-math" --out:/tmp/faster_than_csv.so /tmp/faster_than_csv.nim
 ADD benchmark.py /tmp/

--- a/package4pypi.sh
+++ b/package4pypi.sh
@@ -1,5 +1,5 @@
 rm --verbose --force dist/*.zip
-rm --verbose --force --recursive dist/faster_than_csv/faster_than_csv/
-rm --verbose --force --recursive dist/faster_than_csv/faster_than_csv/__pycache__/
-cp --verbose --recursive faster_than_csv dist/faster_than_csv/
+rm --verbose --force --recursive dist/faster_than_csv/
+rm --verbose --force --recursive dist/faster_than_csv/__pycache__/
+cp --verbose --recursive faster_than_csv dist/
 cd dist && zip -9 -T -v -r faster_than_csv.zip *

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker run --rm -i -t -w /tmp -p 5000:5000 csv-benchmark:1.0    # Run docker.
+docker run --rm -i -t -w /tmp -p 4896:4896 csv-benchmark:1.0    # Run docker.


### PR DESCRIPTION
`nimpy@0.1.1` and the move of the `nim` source folder from `src/` to `faster-than-csv/`.

Also changed the container port to a more "random" one to avoid collisions with other processes or containers already running.

The container builds and runs without issue.

Can even generate the zip file ready to be uploaded to PyPi.

Tested on Ubuntu 20.04

Cheers,
Sekou.